### PR TITLE
Update string_formatting.md

### DIFF
--- a/docs/docs/string_formatting.md
+++ b/docs/docs/string_formatting.md
@@ -143,7 +143,7 @@ The following tokens are currently supported:
 |                                | ZZ            | -0700, -0600 ... +0600, +0700              |
 |                                | z             | Asia/Baku, Europe/Warsaw, GMT ...          |
 |                                | zz            | EST CST ... MST PST                        |
-| **Seconds timestamp**          | X             | 1381685817, 1234567890.123                 |
+| **Seconds timestamp**          | X             | 1381685817                                 |
 | **Microseconds timestamp**     | x             | 1234567890123                              |
 
 


### PR DESCRIPTION
According to [this](https://github.com/sdispater/pendulum/blob/master/pendulum/formatting/formatter.py#L127) line it seems like timestamps (in seconds) are only reported as integers. 

to: @sdispater
